### PR TITLE
Omen: Set Frame Strata and Frame Level higher

### DIFF
--- a/ElvUI_AddOnSkins/Skins/Addons/omen.lua
+++ b/ElvUI_AddOnSkins/Skins/Addons/omen.lua
@@ -22,14 +22,20 @@ local function LoadSkin()
 		if Omen.Options["Skin.Modules.Hide"] then
 			self.BarList:Point("BOTTOMRIGHT", self.ModuleList, "BOTTOMRIGHT")
 		else
-			self.BarList:Point("BOTTOMLEFT", self.ModuleList, "TOPLEFT", 0, -(E.PixelMode and 1 or 3))
-			self.BarList:Point("BOTTOMRIGHT", self.ModuleList, "TOPRIGHT", 0, -(E.PixelMode and 1 or 3))
+			self.BarList:Point("BOTTOMLEFT", self.ModuleList, "TOPLEFT", 0, - (E.PixelMode and 1 or 3))
+			self.BarList:Point("BOTTOMRIGHT", self.ModuleList, "TOPRIGHT", 0, - (E.PixelMode and 1 or 3))
 		end
 
 		if self.activeModule then
 			self.activeModule:UpdateLayout()
 		end
 		self:ResizeBars()
+
+		if self.Anchor then
+			self.Anchor:SetFrameStrata("MEDIUM")
+			self.Anchor:SetFrameLevel(35)
+		end
+
 	end)
 
 	Omen:UpdateDisplay()


### PR DESCRIPTION
Set FrameStrata and FrameLevel for Omen higher.
So the Chat Text does not flow into Omen anymore.
In my case Omen's Frame LEvel is 5 Higher then Recount becasue Omen has priority in most cases!