### PR TITLE
Fix chatframe embed-layering issues

### DIFF
--- a/ElvUI_AddOnSkins/Skins/Addons/omen.lua
+++ b/ElvUI_AddOnSkins/Skins/Addons/omen.lua
@@ -26,10 +26,6 @@ local function LoadSkin()
 			self.BarList:Point("BOTTOMRIGHT", self.ModuleList, "TOPRIGHT", 0, -(E.PixelMode and 1 or 3))
 		end
 
-		if Recount_MainWindow then
-			self.Anchor:SetFrameLevel(Recount_MainWindow:GetFrameLevel() + 5)
-		end
-
 		if self.activeModule then
 			self.activeModule:UpdateLayout()
 		end

--- a/ElvUI_AddOnSkins/modules/embed.lua
+++ b/ElvUI_AddOnSkins/modules/embed.lua
@@ -263,6 +263,12 @@ function EMB:EmbedCreate()
 	self.leftFrame = CreateFrame("Frame", "ElvUI_AddOnSkins_Embed_LeftWindow", self.mainFrame)
 	self.rightFrame = CreateFrame("Frame", "ElvUI_AddOnSkins_Embed_RightWindow", self.mainFrame)
 
+	-- Ensure that the embed-frame is always rendered *above* the chatwindow text to avoid clipping.
+	-- NOTE: "SetFrameStrata" is very unreliable *until* the frame has become visible, hence this solution.
+	hooksecurefunc(self.mainFrame, "Show", function(self)
+		self:SetFrameStrata("MEDIUM")
+	end)
+
 	self.switchButton = CreateFrame("Button", "ElvUI_AddOnSkins_Embed_SwitchButton", UIParent)
 	self.switchButton:Size(120, 32)
 	self.switchButton:RegisterForClicks("AnyUp")


### PR DESCRIPTION
Closes #48.

- The Omen skin had a very strange line which set its FrameLevel to the
  same value as Recount + 5. This totally broke if Recount wasn't also
  loaded, and caused Omen to sit BEHIND chat-text. This code has now
  been removed.

- The actual "mainFrame" of the chat embedding system has now been
  modified to always set *itself* to "MEDIUM" framelevel, thus ensuring
  that *any* current or future addon which is embedded will always
  properly sit above the chat-text. This fixes both Omen and Recount.